### PR TITLE
Add seeds for repeatable deck orders

### DIFF
--- a/public/controller.coffee
+++ b/public/controller.coffee
@@ -4,7 +4,7 @@ root.Controller = do ->
   ## Game Controller
   start = -> 
     if not Model.loadGame()
-      Model.restart()
+      Model.newGame()
   checkSet = -> 
     if Model.checkSet()
       Model.clearSet()

--- a/public/controller.coffee
+++ b/public/controller.coffee
@@ -4,7 +4,7 @@ root.Controller = do ->
   ## Game Controller
   start = -> 
     if not Model.loadGame()
-      Model.newGame()
+      Model.restart()
   checkSet = -> 
     if Model.checkSet()
       Model.clearSet()

--- a/public/header.js
+++ b/public/header.js
@@ -44,10 +44,11 @@ function rand(x) {
   return Math.floor(Math.random() * x);
 }
 
-function shuffle(lst) {
+function shuffle(lst, seed=null) {
+  var randf = seed == null? rand: seeded_prng(seed);
   for (var i = 0; i < lst.length; ++i) {
     var tmp = lst[i]
-    var j = rand(i);
+    var j = randf(i);
     lst[i] = lst[j];
     lst[j] = tmp;
   }
@@ -71,3 +72,36 @@ $.attrHooks['class'] = {
     return value;
   }
 };
+
+
+// blatantly stolen from https://stackoverflow.com/a/47593316
+function xmur3(str) {
+  for(var i = 0, h = 1779033703 ^ str.length; i < str.length; i++)
+      h = Math.imul(h ^ str.charCodeAt(i), 3432918353),
+      h = h << 13 | h >>> 19;
+  return function() {
+      h = Math.imul(h ^ h >>> 16, 2246822507);
+      h = Math.imul(h ^ h >>> 13, 3266489909);
+      return (h ^= h >>> 16) >>> 0;
+  }
+}
+
+function sfc32(a, b, c, d) {
+  return function(x) {
+    a >>>= 0; b >>>= 0; c >>>= 0; d >>>= 0; 
+    var t = (a + b) | 0;
+    a = b ^ b >>> 9;
+    b = c + (c << 3) | 0;
+    c = (c << 21 | c >>> 11);
+    d = d + 1 | 0;
+    t = t + d | 0;
+    c = c + t | 0;
+    var temp = (t >>> 0) / 4294967296;
+    return Math.floor(temp * x);
+  }
+}
+
+function seeded_prng(seed) {
+  var seeder = xmur3(seed);
+  return sfc32(seeder(), seeder(), seeder(), seeder());
+}

--- a/public/hiddenset.html
+++ b/public/hiddenset.html
@@ -75,6 +75,7 @@
         animationTime: 400
       }
 
+      root.initialSeed = window.location.hash.substr(1) || null
       root.variant = Variants.hiddenset
       root.Controller.start()
    </script>

--- a/public/index.html
+++ b/public/index.html
@@ -78,6 +78,7 @@
         animationTime: 400
       }
 
+      root.initialSeed = window.location.hash.substr(1) || null
       root.variant = Variants.set
       root.Controller.start()
    </script>

--- a/public/model.coffee
+++ b/public/model.coffee
@@ -38,7 +38,7 @@ root.Model = do ->
       newGame()
 
   loadGame = ->
-    seed = initialSeed
+    seed = if initialSeed? then initialSeed else null
     gameid = variant.name
     print 'loading', gameid
     if typeof(Storage) isnt 'undefined' and localStorage.getItem(gameid)?

--- a/public/model.coffee
+++ b/public/model.coffee
@@ -8,6 +8,7 @@ root.Model = do ->
   startTime = null
   endTime = null
   phase = null
+  seed = null
 
   getClockTime = ->
     seconds = Math.floor((endTime - startTime) / 1000)
@@ -16,7 +17,7 @@ root.Model = do ->
   deselectAll = -> selected.slice().forEach(deselect)
 
   newGame = ->
-    deck = variant.makeDeck()
+    deck = variant.makeDeck(seed)
     cards = variant.deal(deck)
     selected = []
     startTime = Date.now()
@@ -28,6 +29,8 @@ root.Model = do ->
     View.setLabels(phase)
 
   restart = ->
+    seed = (rand(0x1000000)).toString(16)
+    View.showSeed(seed)
     if phase == 'gameover'
       View.gameOverDone()
       setTimeout(newGame, 1000)
@@ -35,11 +38,15 @@ root.Model = do ->
       newGame()
 
   loadGame = ->
+    seed = initialSeed
     gameid = variant.name
     print 'loading', gameid
     if typeof(Storage) isnt 'undefined' and localStorage.getItem(gameid)?
       game = JSON.parse(localStorage.getItem(gameid))
       if (game? and game.cards? and game.deck? and game.startTime? and game.selected? and game.phase?)
+        if seed != null and seed != game.seed
+          return false
+        seed = game.seed
         cards = game.cards
         deck = game.deck
         startTime = game.startTime
@@ -59,6 +66,7 @@ root.Model = do ->
           View.addCards(cards)
           View.layoutCards()
           View.setLabels(phase)
+          View.showSeed(seed)
           return true
     return false
 
@@ -66,7 +74,7 @@ root.Model = do ->
     gameid = variant.name
     if typeof(Storage) isnt 'undefined'
       gameString = JSON.stringify {
-        cards: cards, deck: deck, startTime: startTime, phase: phase,
+        cards: cards, deck: deck, startTime: startTime, phase: phase, seed: seed,
         selected: [], # do we want to preserve selected cards?
         endTime: endTime, # may be null
       }

--- a/public/powerset.html
+++ b/public/powerset.html
@@ -83,6 +83,7 @@
         if not View.isAnimating()
           if cnt in allowedDimensions
             currentDimensions = cnt
+            root.initialSeed = window.location.hash.substr(1) || null
             root.variant = Variants.powersetWithDimension(currentDimensions)
             root.Controller.start()
       setDimension(6)

--- a/public/superset.html
+++ b/public/superset.html
@@ -75,6 +75,7 @@
         animationTime: 400
       }
 
+      root.initialSeed = window.location.hash.substr(1) || null
       root.variant = Variants.superset
       root.Controller.start()
    </script>

--- a/public/variants.js
+++ b/public/variants.js
@@ -191,12 +191,12 @@ function findPowerSet(cards, previous) {
 function powersetWithDimension(dim) {
   return {
     name: 'Power Set ' + dim,
-    makeDeck: function() {
+    makeDeck: function(seed) {
       var deck = [];
       for (var i = 1; i < (1 << dim); ++i) {
         deck.push({type: '2^' + dim, value: i});
       }
-      return shuffle(deck);
+      return shuffle(deck, seed);
     },
     deal: deal,
     isSet: isPowerSet,

--- a/public/variants.js
+++ b/public/variants.js
@@ -1,4 +1,4 @@
-function makeStandardDeck() {
+function makeStandardDeck(seed) {
   var deck = []
   for(var i = 0; i < 81; ++i) {
     var cur = i;
@@ -8,7 +8,7 @@ function makeStandardDeck() {
     var z = cur;
     deck.push({type: '3^4', count: a, color: b, shading: c, shape: z});
   }
-  return shuffle(deck);
+  return shuffle(deck, seed);
 }
 
 function isNotNull(set) {
@@ -133,8 +133,8 @@ superset = {
 
 hiddenset = {
   name: 'Set',
-  makeDeck: function() {
-    var ret = makeStandardDeck();
+  makeDeck: function(seed) {
+    var ret = makeStandardDeck(seed);
     ret[0].hidden = true;
     return ret;
   },

--- a/public/view.coffee
+++ b/public/view.coffee
@@ -250,6 +250,9 @@ root.View = do ->
     $cards.forEach ($card) -> $card.remove()
     $cards = []
 
+  showSeed = (seed) ->
+    window.location.hash = seed
+
   return {
     select: (i) -> 
       $cards[i].addClass('selected')
@@ -259,6 +262,7 @@ root.View = do ->
     gameOver: gameOver
     gameOverDone: gameOverDone
     clear: clear
+    showSeed: showSeed
 
     setTheme: (theme) -> $body.removeClass('light dark').addClass(theme)
     toggleFullScreen: toggleFullScreen


### PR DESCRIPTION
## Feature Description:
- Games now contain a seed, which are used to shuffle the deck
  - Enables different users to play the same deck order and compare times
- The url fragment is used to display and set the current seed
  - If the fragment is set and doesn't match the currently saved game, loading will fail and a new game will start with the new seed
  - Model.restart will generate a new seed and display it as the fragment

Possibly fulfills https://github.com/stevenhao/set/issues/16 (I didn't even notice this issue before implementing this lol)